### PR TITLE
Fix mob menu for desktop

### DIFF
--- a/src/sass/layouts/_mobile-menu.scss
+++ b/src/sass/layouts/_mobile-menu.scss
@@ -1,3 +1,5 @@
+@media screen and (max-width: 1279px) {
+  
 .mobile-menu {
   top: 0;
   right: 0;
@@ -57,5 +59,6 @@ right: -500px;
   &:focus {
     color: var(--main-red-color);
   }
+}
 }
 


### PR DESCRIPTION
Делает так, чтобы меню не выезжало при 1280 при клике на навигацию хедера